### PR TITLE
Include REST API resource policy to the redeployment trigger

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,10 @@ resource "aws_api_gateway_deployment" "this" {
   rest_api_id = aws_api_gateway_rest_api.this[0].id
 
   triggers = {
-    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.this[0].body))
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_rest_api.this[0].body,
+      local.create_rest_api_policy ? var.rest_api_policy : ""
+    ]))
   }
 
   lifecycle {


### PR DESCRIPTION
## what
- Include the REST API resource policy to the redeployment trigger

## why
- We need to recreate the deployment for the policy changes to take effect

## references
- https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies-create-attach.html#:~:text=My%20resource%20policy%20is%20not%20updating
